### PR TITLE
Add Uni-CLI under Runtimes, Harnesses & Reference Implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ These benchmarks are especially useful when you want to compare harness quality,
 - [AgentKit](https://github.com/inngest/agent-kit) - Inngest's TypeScript toolkit for building durable, workflow-aware agents on top of event-driven infrastructure.
 - [Harbor](https://github.com/harbor-framework/harbor) - A generalized harness for evaluating and improving agents at scale, released alongside Terminal-Bench 2.0.
 - [Harness Evolver](https://github.com/raphaelchristi/harness-evolver) - Claude Code plugin that autonomously evolves LLM agent harnesses using multi-agent proposers, LangSmith-backed evaluation, and git worktree isolation. Based on Meta-Harness (Lee et al., 2026).
+- [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) - Universal CLI hub connecting agents to 134 sites and desktop apps via 711 declarative YAML pipelines. Ships an 8-phase Karpathy-style self-repair loop, eval harness with a starter catalog, per-call cost ledger, hardcoded sensitive-path deny list, and `unicli mcp serve` that auto-registers one MCP tool per adapter. ~80 tokens per invocation.
 
 ## Contributing
 


### PR DESCRIPTION
## One-line summary

Adds Uni-CLI — a universal CLI hub that connects AI agents to 134 sites and desktop apps via declarative YAML pipelines, with a Karpathy-style self-repair loop and a production MCP gateway — under **Runtimes, Harnesses & Reference Implementations**.

## Proposed entry

```md
- [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) - Universal CLI hub connecting agents to 134 sites and desktop apps via 711 declarative YAML pipelines. Ships an 8-phase Karpathy-style self-repair loop, eval harness with a starter catalog, per-call cost ledger, hardcoded sensitive-path deny list, and \`unicli mcp serve\` that auto-registers one MCP tool per adapter. ~80 tokens per invocation.
```

## Why this belongs in the list

The Contributing guidelines ask for resources that are **specific about how agents are constrained, evaluated, resumed, observed, or orchestrated** and **original implementations useful to practitioners building real harnesses**. Uni-CLI is a reference implementation that treats agent safety, observability, and self-repair as first-class concerns:

- **Constrained**: hardcoded sensitive-path deny list (ssh keys, cloud creds, GPG, kube config, 1Password state, npmrc, etc.) blocks \`operate upload\` and the \`exec\` pipeline step before the workspace+home boundary. Cannot be overridden by permission mode. Symlink-aware.
- **Evaluated**: ships an eval harness (\`unicli eval run smoke/<site>\`, \`eval ci --since 7d\`) with a 15-file starter catalog of YAML declarative regression suites. Judges include \`exitCode\`, \`arrayMinLength\`, \`contains\`, \`nonEmpty\`, \`matchesPattern\`.
- **Resumed**: per-call cost ledger at \`~/.unicli/usage.jsonl\` captures every invocation's \`{ts, site, cmd, strategy, tokens, ms, bytes, exit}\`, queryable via \`unicli usage report --since 7d --slow --failing\`.
- **Observed**: structured JSON error contract on stderr with \`adapter_path\`, \`step\`, \`action\`, \`suggestion\` — agent reads the broken 20-line YAML, edits it, retries. This IS the Karpathy self-repair loop, made explicit in 8 phases.
- **Orchestrated**: \`unicli mcp serve\` auto-registers one MCP tool per adapter command (711 tools) for any MCP-aware client. stdio + HTTP/SSE transports.

## Practitioner value

- Single-binary install: \`npm install -g @zenalexa/unicli\`
- ~80 tokens per CLI invocation (~2 orders of magnitude cheaper than per-step LLM stepping)
- Apache-2.0
- 775 unit tests, dist-mode and src-mode parity locked in by regression suite
- Ships with 134 sites (web APIs, desktop software, browser automation, bridges, services) across 35 pipeline steps

## Where it fits in the existing list

Neighboring entries are SWE-agent (research-grade agent with inspectable harness), deepagents (LangChain's harness middleware), AgentKit (Inngest's durable agent toolkit), and Harness Evolver (Claude Code plugin evolving harnesses). Uni-CLI occupies the complementary slot: the **tool layer** that any of these runtimes can call, with self-repair, observability, and MCP-compatibility built in at the CLI boundary rather than pushed into framework middleware.

## Release info

- Current version: **v0.208.0** — [Release notes](https://github.com/olo-dot-io/Uni-CLI/releases/tag/v0.208.0)
- npm: [\`@zenalexa/unicli\`](https://www.npmjs.com/package/@zenalexa/unicli)
- License: Apache-2.0
- Docs: [COMPARE.md](https://github.com/olo-dot-io/Uni-CLI/blob/main/docs/COMPARE.md) has source-level honest comparisons against opencli, CLI-Anything, browser-use, goose, hermes-agent, and Stagehand.

Happy to tweak the wording or placement if you want it in a different position / style.