### PR TITLE
Exclude the bot-blocked preprints.org URL from Link Check

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -23,6 +23,7 @@ jobs:
             --exclude '^https://platform\.openai\.com/docs/guides/agent-evals/?$'
             --exclude '^https://platform\.openai\.com/docs/guides/evaluation-best-practices/?$'
             --exclude '^https://platform\.openai\.com/docs/guides/trace-grading/?$'
+            --exclude '^https://www\.preprints\.org/manuscript/202603\.1756/?$'
             README.md
             CONTRIBUTING.md
           fail: true


### PR DESCRIPTION
## Summary

- exclude the bot-blocked preprints.org URL at `README.md:36` from `Link Check`
- restore green link-check results without changing the curated README entry itself

## Why this scope

Recent merged PRs in this repo tend to be very small, single-purpose, and easy to review. This patch follows that pattern:

- one file changed
- one targeted line added
- no README wording changes
- preserves the primary-source link already accepted into the list

The goal here is only to fix the workflow signal, not to relitigate the entry.

## Why this belongs

The current preprints.org URL is still relevant to harness engineering, but it returns `403 Forbidden` to automated checks. That leaves `Link Check` red on `main`, which conflicts with the repo's explicit quality bar that links should work / remain reachable.

This patch follows the same precedent already present in the workflow for other bot-hostile URLs: keep the curated entry, but exclude the specific false-positive source from automation.

## Validation

Locally reproduced with `lychee 0.23.0` and a GitHub token using the workflow's current exclude set:

- before this change: failing on `https://www.preprints.org/manuscript/202603.1756`
- after this change: exit code `0`

Closes #10

## Checklist

- [x] The change is directly relevant to repo quality and maintenance
- [x] Keeps the diff focused
- [x] Preserves the existing primary-source README entry
- [x] Fixes a reproducible failure in the current workflow

## Notes

I considered replacing the README URL with a reachable mirror, but rejected that because the contributing guide prefers primary sources / original technical write-ups when possible.
