### PR TITLE
Add Lurkr under Constraints, Guardrails & Safe Autonomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Generic agent tooling is out of scope unless the page directly covers harness de
 - [Anchoring AI to a reference application](https://martinfowler.com/articles/exploring-gen-ai/anchoring-to-reference.html) - Thoughtworks on constraining agents with concrete exemplars so they produce more consistent output.
 - [Humans and Agents in Software Engineering Loops](https://martinfowler.com/articles/exploring-gen-ai/humans-and-agents.html) - A clear mental model for where humans should strengthen the harness instead of micromanaging every artifact.
 - [Claude Code: Best practices for agentic coding](https://code.claude.com/docs) - Anthropic's practical recommendations for repo structure, checkpoints, validation, and delegation in agentic coding workflows.
+- [Lurkr](https://github.com/agentveil-protocol/lurkr) - Static scanner that runs in CI before deploy to surface AI-agent capability risks, including shadow capabilities, credentials into LLM context, eval/subprocess in `@tool`, direct prompt interpolation, and unverified MCP endpoints.
 
 ## Specs, Agent Files & Workflow Design
 


### PR DESCRIPTION
Adding Lurkr under Constraints, Guardrails & Safe Autonomy.

The section currently covers guardrail patterns and policy resources mostly at runtime. Lurkr moves part of that concern to pre-deploy: a static scanner that surfaces AI-agent capability risks before the agent ships. Patterns it catches include shadow capabilities (manifest declared tools vs Python tool registrations found by bounded AST analysis), credentials into LLM context, eval/subprocess inside @tool functions, direct prompt interpolation, and unverified MCP server endpoints.

Open source under MIT. Description follows the format in CONTRIBUTING.md: concise harness angle, single sentence.