### PR TITLE
Add new resources to Runtimes, Harnesses & Reference Implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ These benchmarks are especially useful when you want to compare harness quality,
 - [Ralph Wiggum as a Software Engineer](https://ghuntley.com/ralph/) - Geoffrey Huntley's write-up of "Ralph," a minimalist `while :; do cat PROMPT.md | claude-code; done` harness pattern that uses single-task loops, deterministic prompt stacking, and bounded subagent parallelism to drive long-running autonomous coding.
 - [skills.sh](https://skills.sh) - A community marketplace for discovering, sharing, and installing reusable AI agent skills across runtimes like Claude Code and OpenClaw, making harness capabilities portable and composable.
 - [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) - Universal CLI hub connecting agents to 134 sites and desktop apps via 711 declarative YAML pipelines. Ships an 8-phase Karpathy-style self-repair loop, eval harness with a starter catalog, per-call cost ledger, hardcoded sensitive-path deny list, and `unicli mcp serve` that auto-registers one MCP tool per adapter. ~80 tokens per invocation.
+- [Build A Harness](https://github.com/3IVIS/buildaharness) - Open-source (Apache 2.0) visual canvas for designing AI agent harnesses with a runtime-neutral FlowSpec; compiles the same graph to LangGraph, CrewAI, Mastra, or Microsoft Agent Framework, with built-in world-model, control-state, verification, and recovery node types.
 
 ## Contributing
 


### PR DESCRIPTION
Added open source buildaharness to the Runtimes, Harnesses & Reference Implementations

## Summary

- Add or update resource(s) related to harness engineering

## Checklist

- [x] The resource is directly relevant to harness engineering
- [x] The link works
- [x] The resource is not already listed
- [x] The description explains the harness angle clearly
- [x] The change is placed in the most appropriate section

## Notes

Add any context that would help with review.
