### PR TITLE
Add OpenCode Agent Orchestration Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ These benchmarks are especially useful when you want to compare harness quality,
 - [Ralph Wiggum as a Software Engineer](https://ghuntley.com/ralph/) - Geoffrey Huntley's write-up of "Ralph," a minimalist `while :; do cat PROMPT.md | claude-code; done` harness pattern that uses single-task loops, deterministic prompt stacking, and bounded subagent parallelism to drive long-running autonomous coding.
 - [skills.sh](https://skills.sh) - A community marketplace for discovering, sharing, and installing reusable AI agent skills across runtimes like Claude Code and OpenClaw, making harness capabilities portable and composable.
 - [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) - Universal CLI hub connecting agents to 134 sites and desktop apps via 711 declarative YAML pipelines. Ships an 8-phase Karpathy-style self-repair loop, eval harness with a starter catalog, per-call cost ledger, hardcoded sensitive-path deny list, and `unicli mcp serve` that auto-registers one MCP tool per adapter. ~80 tokens per invocation.
+- [OpenCode Agent Orchestration Kit](https://github.com/jcarlosrodicio/opencode-agent-orchestration-kit) - A reproducible OpenCode harness with role-based agents, explicit research-to-review handoffs, local skills, safe configuration installation, and mechanical validation for agent and command contracts.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- Add OpenCode Agent Orchestration Kit under “Runtimes, Harnesses & Reference Implementations”.

## Checklist

- [X] The resource is directly relevant to harness engineering
- [X] The link works
- [X] The resource is not already listed
- [X] The description explains the harness angle clearly
- [X] The change is placed in the most appropriate section

## Notes

This is an OpenCode-focused reference harness rather than a generic agent framework. It provides role-based routing, explicit handoffs across research, design, specification, implementation, and review, repository-local instructions and skills, safe configuration installation, and mechanical validation for agent and command contracts.

The project is intended to be inspectable, version-controlled, and adaptable by developers who want a structured coding-agent workflow.
