### PR TITLE
Add agent-qa

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ These benchmarks are especially useful when you want to compare harness quality,
 - [SWE-ReX](https://github.com/SWE-agent/SWE-ReX) - Sandboxed code execution infrastructure for AI agents, useful when harness work starts to merge into execution runtime design.
 - [AgentKit](https://github.com/inngest/agent-kit) - Inngest's TypeScript toolkit for building durable, workflow-aware agents on top of event-driven infrastructure.
 - [browser-use/browser-harness](https://github.com/browser-use/browser-harness) - A thin CDP-based browser harness that lets agents extend helper functions during execution, useful for inspecting self-healing web-task workflows.
+- [agent-qa](https://github.com/vostride/agent-qa) - A self-improving QA harness for web and mobile workflows, with natural-language tests, memory-backed self-healing, sandboxed hooks, and MCP/skills integration.
 - [Citadel](https://github.com/SethGammon/Citadel) - A harness for Claude Code and OpenAI Codex with isolated worktrees, multi-agent coordination, and persisted memory and campaign state.
 - [Bring Your AI MCP](https://github.com/unitedideas/bringyour-mcp) - Public harness-migration reference for Claude Code to Codex moves, with installable auditor artifacts and explicit validation notes for hooks, MCP config, and instruction-file differences.
 - [Harbor](https://github.com/harbor-framework/harbor) - A generalized harness for evaluating and improving agents at scale, released alongside Terminal-Bench 2.0.


### PR DESCRIPTION
## Summary
- Add agent-qa to Runtimes, Harnesses & Reference Implementations
- Describe the harness-level fit: natural-language QA, memory-backed self-healing, sandboxed hooks, and MCP/skills integration

## Disclosure
I am affiliated with Vostride/agent-qa.

## Checks
- git diff --check