### PR TITLE
Add "Distributed retry patterns" to Constraints, Guardrails & Safe Autonomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Generic agent tooling is out of scope unless the page directly covers harness de
 - [Humans and Agents in Software Engineering Loops](https://martinfowler.com/articles/exploring-gen-ai/humans-and-agents.html) - A clear mental model for where humans should strengthen the harness instead of micromanaging every artifact.
 - [Claude Code: Best practices for agentic coding](https://code.claude.com/docs) - Anthropic's practical recommendations for repo structure, checkpoints, validation, and delegation in agentic coding workflows.
 - [Lurkr](https://github.com/agentveil-protocol/lurkr) - Static scanner that runs in CI before deploy to surface AI-agent capability risks, including shadow capabilities, credentials into LLM context, eval/subprocess in `@tool`, direct prompt interpolation, and unverified MCP endpoints.
+- [Distributed retry patterns: bounding blast radius across a fleet](https://loopandretry.github.io/posts/fleet-retry-patterns/?ref=awesome-harness) - Treating retries as fleet-level infrastructure: bounding concurrent blast radius, backoff, and idempotency so a retry storm doesn't cascade.
 
 ## Specs, Agent Files & Workflow Design
 


### PR DESCRIPTION
Adds one practitioner essay to **Constraints, Guardrails & Safe Autonomy**.

Link: https://loopandretry.github.io/posts/fleet-retry-patterns/

Why it fits: a primary-source technical write-up on treating retries as fleet-level infrastructure — bounding concurrent blast radius, decorrelated backoff, circuit breakers, and idempotency so a retry storm across many agents doesn't cascade into a runaway bill. Same harness/safe-autonomy lane as the existing Inngest and Anthropic entries; it's about *constraining* what a fleet can spend recovering from failure.

Checked against CONTRIBUTING: primary source, non-duplicative, link is live (200), single focused diff, description explains the harness angle rather than promoting.

Disclosure: I write this blog; submitting because it's genuinely on-topic for this section, not a marketing page.