### PR TITLE
Add OpenAgentRelay runtime boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ These benchmarks are especially useful when you want to compare harness quality,
 
 ## Runtimes, Harnesses & Reference Implementations
 
+- [OpenAgentRelay](https://github.com/ShakespeareLabs/open-agent-relay) - A small, inspectable runtime boundary that starts one existing local agent or automation per request and exposes it as a keyed capability over a trusted LAN. Its target-name verification, JSON output, bounded conversations, and explicit exit codes show how a harness can make remote delegation machine-checkable without distributing the publisher's implementation or credentials.
+
 - [HEAAL](https://github.com/hyun06000/AIL) - Grammar-enforced safety constraints for AI agents via AIL (AI-Intent Language).
 
 - [Agent Frameworks, Runtimes, and Harnesses, Oh My!](https://blog.langchain.com/agent-frameworks-runtimes-and-harnesses-oh-my/) - LangChain's decomposition of what belongs in a framework, a runtime, and a harness.


### PR DESCRIPTION
Adds OpenAgentRelay to the runtimes and reference implementations section.

It provides a small, inspectable boundary for exposing one existing local agent or automation over a trusted LAN while keeping implementation details and credentials on the publisher machine. The entry highlights the harness-relevant controls: keyed access, target verification, bounded conversations, JSON output, and explicit exit codes.