### PR TITLE
Add mcp-guardian (MCP proxy for progressive tool discovery + tool scoping)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Generic agent tooling is out of scope unless the page directly covers harness de
 - [Humans and Agents in Software Engineering Loops](https://martinfowler.com/articles/exploring-gen-ai/humans-and-agents.html) - A clear mental model for where humans should strengthen the harness instead of micromanaging every artifact.
 - [Claude Code: Best practices for agentic coding](https://code.claude.com/docs) - Anthropic's practical recommendations for repo structure, checkpoints, validation, and delegation in agentic coding workflows.
 - [Lurkr](https://github.com/agentveil-protocol/lurkr) - Static scanner that runs in CI before deploy to surface AI-agent capability risks, including shadow capabilities, credentials into LLM context, eval/subprocess in `@tool`, direct prompt interpolation, and unverified MCP endpoints.
+- [mcp-guardian](https://github.com/S1LV3RJ1NX/mcp-guardian) - An MIT-licensed MCP proxy that swaps full upstream tool lists for three meta-tools (search_tools, get_schema, execute_tool), enabling progressive tool discovery that cuts session-startup context from ~160k to ~456 tokens across 289 real tools, with scope-based allow/block lists and audit logging so blocked tools can't be discovered, inspected, or called.
 
 ## Specs, Agent Files & Workflow Design
 


### PR DESCRIPTION
## What

Adds [mcp-guardian](https://github.com/S1LV3RJ1NX/mcp-guardian) to the "Constraints, Guardrails & Safe Autonomy" section.

## Why it belongs here

mcp-guardian is a transparent MCP proxy that implements the MCP spec's recommended progressive tool discovery pattern at the infrastructure layer — the client sees three meta-tools (`search_tools`, `get_schema`, `execute_tool`) instead of every upstream tool schema. It works with unmodified clients and unmodified servers.

Harness-relevant specifics:
- **Context control**: session-startup context drops from ~160,143 to ~456 tokens (99.7%) measured against real servers — PostgreSQL MCP (248 tools) + GitHub MCP (41 tools). Break-even is ~39 tools for 95%+ savings.
- **Guardrails**: scope-based allow/blocklists defined in `scope.yaml` (no code changes); blocked tools can't be discovered, inspected, or executed — 27/27 across three attack vectors (search/schema/execute) in testing.
- **Auditability**: every `execute_tool` call is scope-checked and audit-logged before forwarding upstream.
- **Overhead**: ~0ms added latency at tool-execution time (within measurement noise; benchmark in repo).

MIT licensed, Python/FastMCP, Docker-ready. Presented at MCP Dev Summit Bengaluru 2026 ("Putting MCP on a Diet").

## Checklist (per CONTRIBUTING.md)

- [x] Link works and resource is reachable
- [x] Directly about harness-relevant concerns (tool exposure control, context management, safe autonomy)
- [x] Description explains the harness angle, non-promotional
- [x] Not a duplicate of any existing entry
- [x] Single focused diff (one line)

Disclosure: I'm the author of mcp-guardian.