### PR TITLE
Add Agentlas OS Agent Operation Environment (AOE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ These benchmarks are especially useful when you want to compare harness quality,
 - [Ralph Wiggum as a Software Engineer](https://ghuntley.com/ralph/) - Geoffrey Huntley's write-up of "Ralph," a minimalist `while :; do cat PROMPT.md | claude-code; done` harness pattern that uses single-task loops, deterministic prompt stacking, and bounded subagent parallelism to drive long-running autonomous coding.
 - [skills.sh](https://skills.sh) - A community marketplace for discovering, sharing, and installing reusable AI agent skills across runtimes like Claude Code and OpenClaw, making harness capabilities portable and composable.
 - [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) - Universal CLI hub connecting agents to 134 sites and desktop apps via 711 declarative YAML pipelines. Ships an 8-phase Karpathy-style self-repair loop, eval harness with a starter catalog, per-call cost ledger, hardcoded sensitive-path deny list, and `unicli mcp serve` that auto-registers one MCP tool per adapter. ~80 tokens per invocation.
+- [Agentlas OS Agent Operation Environment (AOE)](https://github.com/agentlas-ai/Agentlas-OS) - Local-first agent operation environment that composes specialist teams across supported LLM hosts while keeping execution under host-local tools, permissions, memory boundaries, and verification rules.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Add Agentlas OS Agent Operation Environment (AOE) to Runtimes, Harnesses & Reference Implementations.

The harness angle is the boundary around agent execution: Agentlas composes specialist teams across supported LLM hosts while the selected host retains its local files, tools, credentials, permissions, memory rules, and verification requirements. The public repository documents the package, routing, trust, and execution boundaries.

## Verification

- Confirmed the link is reachable and not already listed
- Kept the change to one concise README entry
- git diff --check

Disclosure: I am submitting this entry on behalf of the Agentlas project.
