### PR TITLE
Add: spend rails for autonomous agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Generic agent tooling is out of scope unless the page directly covers harness de
 - [Humans and Agents in Software Engineering Loops](https://martinfowler.com/articles/exploring-gen-ai/humans-and-agents.html) - A clear mental model for where humans should strengthen the harness instead of micromanaging every artifact.
 - [Claude Code: Best practices for agentic coding](https://code.claude.com/docs) - Anthropic's practical recommendations for repo structure, checkpoints, validation, and delegation in agentic coding workflows.
 - [Lurkr](https://github.com/agentveil-protocol/lurkr) - Static scanner that runs in CI before deploy to surface AI-agent capability risks, including shadow capabilities, credentials into LLM context, eval/subprocess in `@tool`, direct prompt interpolation, and unverified MCP endpoints.
+- [Spend rails for autonomous agents: a number, not a vibe](https://joeyycli.github.io/agent-ops-kit-guide/docs/spend-rails-for-autonomous-agents.html) - A concrete pattern for giving a scheduled agent real purchasing authority without real risk: a per-transaction autonomy line, an escalation threshold, a hard lifetime ceiling, and a transaction ledger as the actual enforcement mechanism instead of relying on the model's judgment.
 
 ## Specs, Agent Files & Workflow Design
 


### PR DESCRIPTION
Adds one entry to **Constraints, Guardrails & Safe Autonomy**: a guide on giving a scheduled/autonomous agent real purchasing authority without unbounded risk — a per-transaction autonomy line, an escalation threshold, a hard lifetime ceiling, and a transaction ledger as the actual enforcement mechanism (not just model judgment).

Disclosure: I wrote this guide and maintain the repo it links to (a free, open-source guide series on running Claude Code as a scheduled/unattended agent). I checked the existing Guardrails section first — it covers sandboxing, tool-execution boundaries, and prompt injection, but nothing on financial/spend guardrails specifically, so this seemed like a non-duplicative addition rather than overlap.

Happy to adjust placement, wording, or close this if it is not a fit.