### PR TITLE
Add Orkas to harness implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ These benchmarks are especially useful when you want to compare harness quality,
 - [Ralph Wiggum as a Software Engineer](https://ghuntley.com/ralph/) - Geoffrey Huntley's write-up of "Ralph," a minimalist `while :; do cat PROMPT.md | claude-code; done` harness pattern that uses single-task loops, deterministic prompt stacking, and bounded subagent parallelism to drive long-running autonomous coding.
 - [skills.sh](https://skills.sh) - A community marketplace for discovering, sharing, and installing reusable AI agent skills across runtimes like Claude Code and OpenClaw, making harness capabilities portable and composable.
 - [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) - Universal CLI hub connecting agents to 134 sites and desktop apps via 711 declarative YAML pipelines. Ships an 8-phase Karpathy-style self-repair loop, eval harness with a starter catalog, per-call cost ledger, hardcoded sensitive-path deny list, and `unicli mcp serve` that auto-registers one MCP tool per adapter. ~80 tokens per invocation.
+- [Orkas](https://github.com/Orkas-AI/Orkas) - A local-first desktop harness for coordinating multiple coding and general-purpose agents with shared files, independent work contexts, human approval gates, and resumable execution. [Website](https://orkas.ai?source=gh-harness)
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- Add Orkas as a local-first desktop harness and reference implementation.

## Checklist

- [x] The resource is directly relevant to harness engineering
- [x] The link works
- [x] The resource is not already listed
- [x] The description explains the harness angle clearly
- [x] The change is placed in the most appropriate section

## Notes

Orkas coordinates multiple coding and general-purpose agents with shared files, independent work contexts, human approval gates, and resumable execution. The project is MIT licensed and supports BYO providers and local model endpoints.

Project: https://github.com/Orkas-AI/Orkas
Website: https://orkas.ai?source=gh-harness