### PR TITLE
Add wiki to Context, Memory & Working State

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Generic agent tooling is out of scope unless the page directly covers harness de
 - [Context-Efficient Backpressure for Coding Agents](https://www.humanlayer.dev/blog/context-efficient-backpressure) - HumanLayer's ideas for preventing agents from burning context on noisy or low-value work.
 - [OpenHands Context Condensensation for More Efficient AI Agents](https://openhands.dev/blog/openhands-context-condensensation-for-more-efficient-ai-agents) - OpenHands' design for bounded conversation memory that preserves goals, progress, critical files, and failing tests while keeping long-running coding sessions efficient.
 - [Writing a good CLAUDE.md](https://www.humanlayer.dev/blog/writing-a-good-claude-md) - A practical guide to creating durable, repo-local instructions that agents can repeatedly follow.
+- [wiki](https://github.com/plasma-ai/wiki) - Indexed Markdown knowledge bases that let agents retrieve project context incrementally, with deterministic indexes, scoped CLI access, and merge handling for parallel edits.
 
 ## Constraints, Guardrails & Safe Autonomy
 


### PR DESCRIPTION
## Summary

- Add [wiki](https://github.com/plasma-ai/wiki) to **Context, Memory & Working State**.
- wiki gives agents incremental access to indexed project knowledge through scoped CLI commands, deterministic indexes, linting, and merge handling for parallel edits.

## Checklist

- [x] The resource is directly relevant to harness engineering
- [x] The link works
- [x] The resource is not already listed
- [x] The description explains the harness angle clearly
- [x] The change is placed in the most appropriate section

## Notes

Disclosure: I'm affiliated with the project.