### PR TITLE
Add Codex How To learning resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Generic agent tooling is out of scope unless the page directly covers harness de
 ## Courses & Learning Resources
 
 - [walkinglabs/learn-harness-engineering](https://github.com/walkinglabs/learn-harness-engineering) - A project-based course repository on making Codex and Claude Code more reliable, centered on an Electron personal knowledge base app with lecture handouts, example artifacts, and practical harness projects.
+- [Phelan164/codex-howto](https://github.com/Phelan164/codex-howto) - A Codex-focused engineering curriculum with installable skills, repository instructions, scoped permissions, testing, review, orchestration, and reproducible token measurements for building an inspectable coding-agent harness.
 
 ## Foundations
 


### PR DESCRIPTION
## Summary

- Add `Phelan164/codex-howto` to Courses & Learning Resources.

The guide is a Codex-focused, engineering-first curriculum covering repo-local
instructions, sandbox and approval boundaries, installable workflow skills,
testing and review gates, orchestration, and controlled skill-ablation
measurements.

I maintain the submitted project. The entry is intentionally concise and
describes the harness primitives readers can inspect rather than making a
general productivity claim.

## Checklist

- [x] The resource is directly relevant to harness engineering
- [x] The link works
- [x] The resource is not already listed
- [x] The description explains the harness angle clearly
- [x] The change is placed in the most appropriate section

## Notes

- Verified `https://github.com/Phelan164/codex-howto` returns HTTP 200.
- Confirmed there is no existing README entry or open/closed submission for the
  project.
- `git diff --check` passes.
- Automated assistance helped research the catalog and draft the entry; the
  linked repository and its published measurement receipts are the primary
  evidence.
