### PR TITLE
docs: add DeepSeek Harness Handbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Generic agent tooling is out of scope unless the page directly covers harness de
 ## Courses & Learning Resources
 
 - [walkinglabs/learn-harness-engineering](https://github.com/walkinglabs/learn-harness-engineering) - A project-based course repository on making Codex and Claude Code more reliable, centered on an Electron personal knowledge base app with lecture handouts, example artifacts, and practical harness projects.
+- [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook) - An agent-first, source-backed guide to operating and extending DeepSeek Harness, with practical coverage of runtime composition, session events, tool policy, sandbox boundaries, MCP, headless CI, and platform-specific failure modes.
 
 ## Foundations
 


### PR DESCRIPTION
## Summary

Adds the DeepSeek Harness Handbook to Courses & Learning Resources.

## Why it fits

- directly covers harness composition, session state, tool execution, approval, and sandbox boundaries
- includes practical Web, headless CI, Python SDK, MCP, and troubleshooting workflows
- links version-sensitive claims to official DeepSeek Harness sources and records verification dates
- is not already present in the list

The change follows the requested one-entry format and keeps the diff focused.