### PR TITLE
Add DSH Studio runtime supervisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ These benchmarks are especially useful when you want to compare harness quality,
 - [SWE-ReX](https://github.com/SWE-agent/SWE-ReX) - Sandboxed code execution infrastructure for AI agents, useful when harness work starts to merge into execution runtime design.
 - [AgentKit](https://github.com/inngest/agent-kit) - Inngest's TypeScript toolkit for building durable, workflow-aware agents on top of event-driven infrastructure.
 - [browser-use/browser-harness](https://github.com/browser-use/browser-harness) - A thin CDP-based browser harness that lets agents extend helper functions during execution, useful for inspecting self-healing web-task workflows.
+- [DSH Studio](https://github.com/Moresyl/dsh-studio) - Cross-platform desktop host for DeepSeek Harness that makes runtime control inspectable through local installation, HTTP health probes, restart backoff, collision-free ports, and whole-process-tree cleanup.
 - [Citadel](https://github.com/SethGammon/Citadel) - A harness for Claude Code and OpenAI Codex with isolated worktrees, multi-agent coordination, and persisted memory and campaign state.
 - [Bring Your AI MCP](https://github.com/unitedideas/bringyour-mcp) - Public harness-migration reference for Claude Code to Codex moves, with installable auditor artifacts and explicit validation notes for hooks, MCP config, and instruction-file differences.
 - [Harbor](https://github.com/harbor-framework/harbor) - A generalized harness for evaluating and improving agents at scale, released alongside Terminal-Bench 2.0.


### PR DESCRIPTION
## Summary

- Add DSH Studio to **Runtimes, Harnesses & Reference Implementations** as a focused self-submission.

## Checklist

- [x] The resource is directly relevant to harness engineering
- [x] The link works
- [x] The resource is not already listed
- [x] The description explains the harness angle clearly
- [x] The change is placed in the most appropriate section

## Notes

DSH Studio is a cross-platform desktop host for DeepSeek Harness. The entry focuses on inspectable runtime-reliability primitives rather than generic AI tooling: local harness installation, real HTTP health probes, restart backoff, OS-assigned ports, and whole-process-tree cleanup through Windows Job Objects or Unix process groups.

The diff adds one entry and changes no existing resources.