### PR TITLE
Add OpenViking to Runtimes, Harnesses & Reference Implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ These benchmarks are especially useful when you want to compare harness quality,
 - [Ralph Wiggum as a Software Engineer](https://ghuntley.com/ralph/) - Geoffrey Huntley's write-up of "Ralph," a minimalist `while :; do cat PROMPT.md | claude-code; done` harness pattern that uses single-task loops, deterministic prompt stacking, and bounded subagent parallelism to drive long-running autonomous coding.
 - [skills.sh](https://skills.sh) - A community marketplace for discovering, sharing, and installing reusable AI agent skills across runtimes like Claude Code and OpenClaw, making harness capabilities portable and composable.
 - [Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) - Universal CLI hub connecting agents to 134 sites and desktop apps via 711 declarative YAML pipelines. Ships an 8-phase Karpathy-style self-repair loop, eval harness with a starter catalog, per-call cost ledger, hardcoded sensitive-path deny list, and `unicli mcp serve` that auto-registers one MCP tool per adapter. ~80 tokens per invocation.
+- [OpenViking](https://github.com/volcengine/OpenViking) - Self-evolving context database for AI agents unifying agent memory, knowledge RAG, and skills behind one storage/retrieval layer, with an MCP server for reading and writing memory during a harness run.
 
 ## Contributing
 


### PR DESCRIPTION
Adds [OpenViking](https://github.com/volcengine/OpenViking) (volcengine, ~28.5k stars) as a reference implementation.

It's a self-evolving context database that unifies agent memory, knowledge RAG, and skills behind one storage/retrieval layer, exposing an MCP server so a harness can read and write memory during a run — a concrete, inspectable implementation of context/memory management, in the spirit of the other reference implementations already listed here (Citadel, Harbor, deepagents).
