### PR TITLE
Add Deterministic Context Routing to Context, Memory & Working State

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Generic agent tooling is out of scope unless the page directly covers harness de
 - [Context-Efficient Backpressure for Coding Agents](https://www.humanlayer.dev/blog/context-efficient-backpressure) - HumanLayer's ideas for preventing agents from burning context on noisy or low-value work.
 - [OpenHands Context Condensensation for More Efficient AI Agents](https://openhands.dev/blog/openhands-context-condensensation-for-more-efficient-ai-agents) - OpenHands' design for bounded conversation memory that preserves goals, progress, critical files, and failing tests while keeping long-running coding sessions efficient.
 - [Writing a good CLAUDE.md](https://www.humanlayer.dev/blog/writing-a-good-claude-md) - A practical guide to creating durable, repo-local instructions that agents can repeatedly follow.
+- [Deterministic Context Routing](https://github.com/ai-erp-collab/deterministic-context-routing) - A context-management methodology that routes only the necessary-and-sufficient context to an agent through a deterministic chain (module registry → wiki → session state), cutting overread and context loss on large, under-documented multi-module codebases.
+
 
 ## Constraints, Guardrails & Safe Autonomy
 


### PR DESCRIPTION
## Summary

Adds **Deterministic Context Routing** to the *Context, Memory & Working State* section.

DCR is a context-management methodology for AI agents working on large, under-documented codebases. Instead of giving the agent access to everything and letting it search, it defines a fixed routing chain — module registry → module concept → wiki/contracts → artifact index → session state — and loads only the necessary-and-sufficient context for the current task.

## Why it belongs here (harness angle)

- **Context engineering:** directly addresses the core harness problem of giving agents the right context without overread or context loss.
- **Working-state management:** uses `session_state.md` with stop markers as short-term memory for cross-session continuity.
- **Confidence labels:** every claim is tagged (confirmed / inferred / runtime-unverified / blocked) so agents don't present guesses as facts.
- **Empirically validated:** A/B test on a proprietary ERP (no compiler, no Git) showed ~74% fewer files read (23 → 6), zero overread, and zero unqualified claims.

## Checklist

- [x] Link works
- [x] Resource is about harness-relevant concerns (context routing)
- [x] Description is accurate, not promotional
- [x] No duplicate in README
- [x] Focused diff (single line)