### PR TITLE
docs: add SandBase Harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ These benchmarks are especially useful when you want to compare harness quality,
 - [Building agents with the Claude Agent SDK](https://claude.com/blog/building-agents-with-the-claude-agent-sdk) - Anthropic's guide to a production-oriented agent SDK with sessions, tools, and orchestration support.
 - [How we built our multi-agent research system](https://www.anthropic.com/engineering/multi-agent-research-system) - Anthropic's architecture write-up for a multi-agent system with separation of roles and structured coordination.
 - [deepagents](https://github.com/langchain-ai/deepagents) - LangChain's open-source project for building deeper, longer-running agents with middleware and harness patterns.
+- [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) - A local-first agent runtime that puts persistent sessions, governed MCP tools, credential handling, audit and replay, and local, Docker, Kubernetes, or worker-queue sandboxes behind a Claude Managed Agents-style API.
 - [SWE-agent](https://github.com/SWE-agent/SWE-agent) - A mature research coding agent that makes the harness, prompt, tools, and environment design directly inspectable.
 - [SWE-ReX](https://github.com/SWE-agent/SWE-ReX) - Sandboxed code execution infrastructure for AI agents, useful when harness work starts to merge into execution runtime design.
 - [AgentKit](https://github.com/inngest/agent-kit) - Inngest's TypeScript toolkit for building durable, workflow-aware agents on top of event-driven infrastructure.


### PR DESCRIPTION
## Summary

Add SandBase Harness to **Runtimes, Harnesses & Reference Implementations**.

The description focuses on inspectable harness-level behavior documented by the project: persistent sessions, governed MCP tools, credential handling, audit/replay, and multiple sandbox backends behind a managed-agent API.

## Checks

- link is reachable
- no existing SandBase entry or PR
- project is active and Apache-2.0 licensed
- `git diff --check`

Disclosure: I am contributing on behalf of the SandBase project.