### PR TITLE
Add awesome-agentic-ai to Courses & Learning Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Generic agent tooling is out of scope unless the page directly covers harness de
 - [walkinglabs/learn-harness-engineering](https://github.com/walkinglabs/learn-harness-engineering) - A project-based course repository on making Codex and Claude Code more reliable, centered on an Electron personal knowledge base app with lecture handouts, example artifacts, and practical harness projects.
 - [Phelan164/codex-howto](https://github.com/Phelan164/codex-howto) - A Codex-focused engineering curriculum with installable skills, repository instructions, scoped permissions, testing, review, orchestration, and reproducible token measurements for building an inspectable coding-agent harness.
 - [hardness1020/awesome-agent-architecture](https://github.com/hardness1020/awesome-agent-architecture) - Trilingual architecture notes and runnable demos covering agent loops, tool execution, memory, permissions, context delivery, and orchestration.
+- [awesome-agentic-ai](https://github.com/adriannoes/awesome-agentic-ai) - Learning hub with a vendored harness skill, spec-driven PM templates, and curated papers on agentic coding — complements course-style repos like awesome-agent-architecture.
 
 ## Foundations
 


### PR DESCRIPTION
Adds one learning hub under **Courses & Learning Resources**, next to awesome-agent-architecture.

https://github.com/adriannoes/awesome-agentic-ai

Why it fits this list: you curate harness engineering, SDD, and coding-agent reliability. The hub is not a harness product — it indexes a harness skill, spec-driven workflows (PRD → tasks → execute), and learning material (papers, notebooks) for people building agentic coding setups with Claude Code, Cursor, and Codex.

MIT. Public. Maintained since Oct 2025. One link.